### PR TITLE
lumen 0.10.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 
 build_artifacts
+# Cursor temporary files
+/.cursor/tmp/

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/kanaries-track-feedstock/pr1/398acb7
-  - https://staging.continuum.io/preprod-pbp/fs/ipylab-feedstock/pr1/482566f
-  - https://staging.continuum.io/preprod-pbp/fs/segment-analytics-python-feedstock/pr2/574f6e6
-  - https://staging.continuum.io/pbp/fs/python-quickjs-feedstock/pr1/ed06515
-  - https://staging.continuum.io/pbp/fs/pygwalker-feedstock/pr1/397b411

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/kanaries-track-feedstock/pr1/398acb7
+  - https://staging.continuum.io/preprod-pbp/fs/ipylab-feedstock/pr1/482566f
+  - https://staging.continuum.io/preprod-pbp/fs/segment-analytics-python-feedstock/pr2/574f6e6
+  - https://staging.continuum.io/pbp/fs/python-quickjs-feedstock/pr1/ed06515
+  - https://staging.continuum.io/pbp/fs/pygwalker-feedstock/pr1/397b411

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/preprod-pbp/fs/mpire-feedstock/pr1/5d9265b
+  - https://staging.continuum.io/preprod-pbp/fs/semchunk-feedstock/pr1/c7e85be

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/mpire-feedstock/pr1/5d9265b
-  - https://staging.continuum.io/preprod-pbp/fs/semchunk-feedstock/pr1/c7e85be

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "lumen" %}
-{% set version = "0.9.0" %}
+{% set version = "0.10.1" %}
 
 package:
   name: {{ name|lower }}-bundle
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 575a9ef9444eda55a087c0201345d12ce1743f702538cf3170803a4c57d671e6
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 4ab077bf87357649c3b75a1776ab9655b246b766efddf96e5dbefaab3781b568
 
 build:
   number: 0
@@ -27,7 +27,7 @@ outputs:
         - hatch-vcs
       run:
         - python
-        - panel >=1.5.0
+        - panel >=1.6.3
         - hvplot
         - holoviews >=1.17.0
         - pandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ outputs:
     build:
       entry_points:
         - lumen = lumen.command:main
-      skip: true  # [py<310]
+      skip: true  # [py<310 or win]
       script: python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
     requirements:
@@ -92,7 +92,7 @@ outputs:
 
   - name: {{ name|lower }}-ai
     build:
-      skip: true  # [py<310 or win]
+      skip: true  # [py<310]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,8 +91,6 @@ outputs:
 #  it has been decided to skip the builds for all of Lumen's additional AI outputs.
 
   - name: {{ name|lower }}-ai
-    build:
-      skip: True
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ outputs:
     build:
       entry_points:
         - lumen = lumen.command:main
+      # pygwalker not available on win
       skip: true  # [py<310 or win]
       script: python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ outputs:
         - lumen = lumen.command:main
       skip: True  # [py<310]
       script: python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+
     requirements:
       host:
         - python
@@ -91,6 +92,8 @@ outputs:
 #  it has been decided to skip the builds for all of Lumen's additional AI outputs.
 
   - name: {{ name|lower }}-ai
+    build:
+      skip: true  # [py<310]
     requirements:
       host:
         - python
@@ -117,7 +120,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-local
     build:
-      skip: True
+      skip: true
     requirements:
       host:
         - python
@@ -133,7 +136,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-openai
     build:
-      skip: True
+      skip: true
     requirements:
       host:
         - python
@@ -149,7 +152,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-mistralai
     build:
-      skip: True
+      skip: true
     requirements:
       host:
         - python
@@ -165,7 +168,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-anthropic
     build:
-      skip: True
+      skip: true
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ outputs:
     build:
       entry_points:
         - lumen = lumen.command:main
-      skip: True  # [py<310]
+      skip: true  # [py<310]
       script: python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
     requirements:
@@ -120,7 +120,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-local
     build:
-      skip: true
+      skip: true  # [py<310]
     requirements:
       host:
         - python
@@ -136,7 +136,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-openai
     build:
-      skip: true
+      skip: true  # [py<310]
     requirements:
       host:
         - python
@@ -152,7 +152,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-mistralai
     build:
-      skip: true
+      skip: true  # [py<310]
     requirements:
       host:
         - python
@@ -168,7 +168,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-anthropic
     build:
-      skip: true
+      skip: true  # [py<310]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -92,7 +92,7 @@ outputs:
 
   - name: {{ name|lower }}-ai
     build:
-      skip: true  # [py<310]
+      skip: true  # [py<310 or win]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -108,12 +108,12 @@ outputs:
         - pydantic >=2.8.0
         - pydantic-extra-types
         - panel-graphic-walker >=0.6.4
+        - gw-dsl-parser
+        - pygwalker >=0.4.9.11
         - markitdown
         - tiktoken
         - chardet
         - semchunk
-        - gw-dsl-parser
-        - pygwalker >=0.4.9.11
     about:
       home: https://github.com/holoviz/lumen
       summary: 'Lumen with AI capabilities'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,8 +88,6 @@ outputs:
 # - lumen-ai-openai: Metapackage that adds OpenAI support
 # - lumen-ai-mistralai: Metapackage that adds MistralAI support
 # - lumen-ai-anthropic: Metapackage that adds Anthropic support
-# Until all of the neccesary panel-graphic-walker[kernel] packages are available in defaults,
-#  it has been decided to skip the builds for all of Lumen's additional AI outputs.
 
   - name: {{ name|lower }}-ai
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ outputs:
         - pydantic >=2.8.0
         - panel-graphic-walker >=0.6.4
         - llama-cpp-python >=0.3.0
+        - duckdb >=1.2.0
     test:
       # source_files:
       #   - lumen/tests
@@ -110,6 +111,7 @@ outputs:
         - markitdown
         - tiktoken
         - chardet
+        - semchunk
     about:
       home: https://github.com/holoviz/lumen
       summary: 'Lumen with AI capabilities'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -92,7 +92,7 @@ outputs:
 
   - name: {{ name|lower }}-ai
     build:
-      skip: true  # [py<310]
+      skip: true  # [py<310 or win]
     requirements:
       host:
         - python
@@ -122,7 +122,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-local
     build:
-      skip: true  # [py<310]
+      skip: true  # [py<310 or win]
     requirements:
       host:
         - python
@@ -138,7 +138,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-openai
     build:
-      skip: true  # [py<310]
+      skip: true  # [py<310 or win]
     requirements:
       host:
         - python
@@ -154,7 +154,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-mistralai
     build:
-      skip: true  # [py<310]
+      skip: true  # [py<310 or win]
     requirements:
       host:
         - python
@@ -170,7 +170,7 @@ outputs:
 
   - name: {{ name|lower }}-ai-anthropic
     build:
-      skip: true  # [py<310]
+      skip: true  # [py<310 or win]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -112,6 +112,8 @@ outputs:
         - tiktoken
         - chardet
         - semchunk
+        - gw-dsl-parser
+        - pygwalker >=0.4.9.11
     about:
       home: https://github.com/holoviz/lumen
       summary: 'Lumen with AI capabilities'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,7 @@ outputs:
     build:
       entry_points:
         - lumen = lumen.command:main
-      # pygwalker not available on win
-      skip: true  # [py<310 or win]
+      skip: true  # [py<310]
       script: python -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
     requirements:
@@ -47,11 +46,10 @@ outputs:
         - llama-cpp-python >=0.3.0
         - duckdb >=1.2.0
     test:
-      # source_files:
-      #   - lumen/tests
+      source_files:
+        - lumen/tests
       imports:
         - lumen
-        # - lumen.ai
         - lumen.auth
         - lumen.command
         - lumen.tests
@@ -60,16 +58,20 @@ outputs:
         - lumen.views
       requires:
         - pip
-        # - pydantic
-        # - duckdb
-        # - instructor
-        # - griffe
-        # - pydantic-extra-types
-        # - jsonschema
-        # - nbformat
+        - pydantic
+        - duckdb
+        - instructor
+        - griffe
+        - pydantic-extra-types
+        - jsonschema
+        - nbformat
       commands:
         - pip check
         - lumen --help
+        # - pytest lumen/tests -v
+        # Upstream tests (pytest lumen/tests -v) are disabled due to dependency version
+        # conflicts with pandas 2.3+/pyarrow StringDtype changes, dask 2024+ legacy API
+        # removal, and bokeh version incompatibilities between panel and dask requirements
     about:
       home: https://github.com/holoviz/lumen
       summary: 'Illuminate your data. A monitoring solution built on Panel'
@@ -93,6 +95,7 @@ outputs:
 
   - name: {{ name|lower }}-ai
     build:
+      # pygwalker not available on win
       skip: true  # [py<310 or win]
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -112,7 +112,6 @@ outputs:
         - pydantic >=2.8.0
         - pydantic-extra-types
         - panel-graphic-walker >=0.6.4
-        - gw-dsl-parser
         - pygwalker >=0.4.9.11
         - markitdown
         - tiktoken


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-8402](https://anaconda.atlassian.net/browse/PKG-8402)
- [Upstream repository](https://github.com/holoviz/lumen/tree/v0.10.1)
- [Upstream changelog/diff](https://github.com/holoviz/lumen/releases)
- https://package-build.anaconda.com/v1/graph/a2fc3944-2b72-471a-8b33-5bda08ab3fa1

### Explanation of changes:

- Update version and sha256
- Update dependencies
- enable `lumen-ai`

### Notes

- Supporting upstream tests would require updates to a few different packages

[PKG-8402]: https://anaconda.atlassian.net/browse/PKG-8402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ